### PR TITLE
cleared the issue [Feature]: Save User’s Last Map View (Zoom & Locat…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/script.js
+++ b/script.js
@@ -30,10 +30,38 @@ function loadDynamicEvents() {
 
 loadDynamicEvents();
 
-let map = L.map("map").setView([28.6139, 77.209], 13);
+// Function to save map position
+function saveMapPosition() {
+  const position = {
+    lat: map.getCenter().lat,
+    lng: map.getCenter().lng,
+    zoom: map.getZoom()
+  };
+  localStorage.setItem('mapPosition', JSON.stringify(position));
+}
+
+// Function to get saved map position
+function getSavedMapPosition() {
+  const saved = localStorage.getItem('mapPosition');
+  if (saved) {
+    return JSON.parse(saved);
+  }
+  // Default position (Delhi)
+  return { lat: 28.6139, lng: 77.209, zoom: 13 };
+}
+
+// Get saved position or use default
+const savedPosition = getSavedMapPosition();
+
+// Initialize map with saved position
+let map = L.map("map").setView([savedPosition.lat, savedPosition.lng], savedPosition.zoom);
+
 L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
   attribution: "&copy; OpenStreetMap contributors",
 }).addTo(map);
+
+// Save position when map moves
+map.on('moveend', saveMapPosition);
 
 const markerGroup = L.layerGroup().addTo(map);
 


### PR DESCRIPTION
 #72 issue


# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

Please describe what this PR does and link any related issues.
Implemented logic to save the user's last viewed map position (latitude, longitude, and zoom level) using localStorage. Upon page reload, the map restores to the saved position.

This enhancement improves the user experience by preserving context.
Example: If a user zooms into Hyderabad and refreshes the page, they will now return to Hyderabad instead of the default map view.

Fixes: #72 

## 📂 Type of Change

- [ ] Bug Fix 🐛
- [ .] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [ .] My code follows the contribution guidelines of Civix
- [ .] I have tested my changes locally
- [ .] I have updated relevant documentation
- [ .] I have linked related issues (if any)
- [ .] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Include screenshots or screen recordings of your change.
