### PR TITLE
Fixed map visibility in smaller window

### DIFF
--- a/Home.css
+++ b/Home.css
@@ -510,6 +510,10 @@ footer {
     .hero-content {
         max-width: 100%;
     }
+
+    .hero-image{
+        width : 100%;
+    }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
# 📦 Pull Request: Fixed map visibility in smaller window

## ✅ Description

Previously the in a smaller window the map was not visible in a window of width 992 pixels or smaller.
Related Issue #104 

Fixes: #104 
Added CSS code to so the map can occupy all the space assigned  to it.
Now the whole interface is responsive according to screen resolution. 

## 📂 Type of Change
- [✔️ ] Bug Fix 🐛

## 📋 Checklist

- [✔️  ] My code follows the contribution guidelines of Civix
- [✔️  ] I have tested my changes locally
- [✔️  ] I have updated relevant documentation
- [✔️  ] I have linked related issues (if any)
- [✔️  ] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

![image](https://github.com/user-attachments/assets/6aa38f6d-c734-4835-8b99-c25d428718a3)

