### PR TITLE
fix zoom button overlap on explore page

### DIFF
--- a/components/map/MapExplorer.js
+++ b/components/map/MapExplorer.js
@@ -592,6 +592,7 @@ const MapExplorer = ({ events = [], onEventAdded, onEventDeleted, isAuthenticate
         }
         
         .map-container {
+          z-index : 800;
           flex: 1;
           position: relative;
         }


### PR DESCRIPTION
# 📦 Pull Request: Fix zoom button overlap on explore page

## ✅ Description

The zoom button previously were overlapping with the explore page header.

Fixes: #166 

## 📂 Type of Change

- [✔️] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [✔️ ] My code follows the contribution guidelines of Civix
- [✔️ ] I have tested my changes locally
- [✔️ ] I have updated relevant documentation
- [ ✔️] I have linked related issues (if any)
- [ ✔️] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

![image](https://github.com/user-attachments/assets/e465ff4d-65e4-4a7f-96ed-8a93f43eb9f6)
