### PR TITLE
Fix FAQ items expanding behaviour

### DIFF
--- a/components/sections/FAQSection.js
+++ b/components/sections/FAQSection.js
@@ -132,6 +132,7 @@ const FAQSection = () => {
         
         .faq-item {
           background-color: var(--background);
+          max-height: calc(1lh + 2rem);
           border-radius: 12px;
           overflow: hidden;
           transition: all 0.3s ease;
@@ -147,6 +148,7 @@ const FAQSection = () => {
         .faq-item.active {
           box-shadow: 0 8px 30px rgba(var(--primary-rgb), 0.15);
           border-color: rgba(var(--primary-rgb), 0.2);
+          max-height: unset
         }
         
         .faq-question {


### PR DESCRIPTION
# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

Please describe what this PR does and link any related issues.

Fixes: #195 

The behavior before was that the height of the faq-items automatically scaled to fill the extra height made by the neighboring faq-item.

Now by default their height is hard-coded to be the line height plus the padding that was already set (1 rem above and below).
For non-active items, set max-height to this constant height, and for active items unset this limit.

Did simple tests by resizing page, and the UI didn’t seem to break in any way. Looking at compatibility for `lh`unit and `calc()`, support is extremely high [96.61%](https://caniuse.com/calc) and [91.58%](https://caniuse.com/mdn-css_types_length_lh)

I want to note that i did notice the file `src/styles/faq.css` but when adding the modifications there it didn't have any effect, so i dropped editing it and just modified `components/sections/FAQSection.js` directly.

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [x] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [x] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

![image](https://github.com/user-attachments/assets/ce64e6e2-ec2f-421b-88ec-eac00a1c31c0)

Include screenshots or screen recordings of your change.
