### PR TITLE
fix: prevent AOS from re-animating FAQ accordion items on click

### DIFF
--- a/components/sections/FAQSection.js
+++ b/components/sections/FAQSection.js
@@ -49,8 +49,6 @@ const FAQSection = () => {
               <div 
                 className={`faq-item ${activeIndex === index ? 'active' : ''}`} 
                 key={index}
-                data-aos="fade-up"
-                data-aos-delay={100 + (index * 50)}
               >
                 <div 
                   className="faq-question"


### PR DESCRIPTION
# 📦 Pull Request: Fix FAQ AOS Animation Bug (#216)

## ✅ Description

This PR fixes a bug where FAQ accordion items would flash or fade on click due to a conflict with the Animate On Scroll (AOS) library.  
**Root Cause:** The FAQ items used `data-aos` attributes, causing AOS to re-animate them on every state change (expand/collapse).  
**Solution:** Removed `data-aos` attributes from interactive FAQ items, keeping scroll animations only on static section elements.

Fixes: #216 

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [ ] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Demo 




https://github.com/user-attachments/assets/8324e298-b436-40a6-8ef1-10202807a678


