### PR TITLE
Fix Custom Cursor Overlap with Default Cursor on Interactive

### DIFF
--- a/components/Cursor.jsx
+++ b/components/Cursor.jsx
@@ -51,7 +51,7 @@ const Cursor = () => {
       </div>
 
       <style jsx global>{`
-        body, html {
+        * {
           cursor: none !important; /* Force hide default cursor */
         }
         


### PR DESCRIPTION

# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

This PR resolves the issue where the default system cursor reappears on interactive elements like buttons, inputs and links, even when a custom cursor is active.

Fixes: #236 

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [x] I have updated relevant documentation
- [x] I have linked related issues
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)
I've attached a video that shows that now the cursor is working perfectly without getting overlapped by default cursor
https://github.com/user-attachments/assets/1cdf2d17-b9fa-4fc2-88d0-e99da43187dc




