### PR TITLE
Fix: Resolve overlapping logo in navbar

### DIFF
--- a/components/layout/Navbar.js
+++ b/components/layout/Navbar.js
@@ -113,7 +113,7 @@ const Navbar = () => {
 
             <img src={isDarkMode?'/loggd.svg' : '/logg.svg'} alt="EventMappr Logo" className="hidden dark:block h-8 w-auto" style={{ width: '200px' }}/>
 
-            <img src="/loggd.svg" alt="EventMappr Logo" className="h-8 w-auto" style={{ width: '400px'}} />
+            
 
           </a>
         </Link>


### PR DESCRIPTION
✅ Description
This pull request resolves a visual bug where the "EventMappr" logo was overlapping in the navigation bar.

The issue was caused by a duplicate <img> tag within the Navbar.js component. This PR removes the extra tag, ensuring only a single logo is rendered, which correctly handles both light and dark themes.

Fixes: #235 

📂 Type of Change
[x] Bug Fix 🐛

📋 Checklist
[x] My code follows the contribution guidelines of this project

[x] I have tested my changes locally

[x] This pull request is ready to be reviewed

🎥 Screenshots 
<img width="1920" height="1080" alt="Screenshot 2025-07-23 135621" src="https://github.com/user-attachments/assets/56c85bcd-15bc-46d8-9c38-a331d5eea2b9" />

