### PR TITLE
ENHANCE : alignment in contact us

### DIFF
--- a/components/sections/FAQSection.js
+++ b/components/sections/FAQSection.js
@@ -204,7 +204,7 @@ const FAQSection = () => {
         
         .faq-cta {
           text-align: center;
-          margin-top: 3rem;
+          margin-top: 8rem;
         }
         
         .faq-cta p {
@@ -259,13 +259,13 @@ const FAQSection = () => {
         }
         
         .btn-icon {
-          margin-right: 0.8rem;
+          margin-right: 0.35rem;
           font-size: 1.2rem;
           transition: transform 0.3s ease;
         }
         
         .bubble-btn:hover .btn-icon {
-          transform: scale(1.2);
+          transform: scale(1.05);
         }
         
         .btn-text {


### PR DESCRIPTION
# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

Please describe what this PR does and link any related issues.

this pr provide margin-top to the p tag and reduce margin-left of contact us icon so that contact us text doesn't move to the right of the button.

Fixes: #291 

## 📂 Type of Change

- [ ] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [/ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [/ ] My code follows the contribution guidelines of Eventmappr
- [/ ] I have tested my changes locally
- [/ ] I have updated relevant documentation
- [ /] I have linked related issues (if any)
- [ /] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Include screenshots or screen recordings of your change.
before--
<img width="1900" height="355" alt="Screenshot 2025-07-28 120606" src="https://github.com/user-attachments/assets/16538700-c995-4a81-a7f3-61104f1b42fa" />

after--
<img width="1914" height="931" alt="Screenshot 2025-08-01 145120" src="https://github.com/user-attachments/assets/97b9888f-8b36-45d3-b9ea-adc248e243a0" />

