### PR TITLE
fix: Improve homepage section's background contrast for light mode

### DIFF
--- a/components/sections/FAQSection.js
+++ b/components/sections/FAQSection.js
@@ -260,7 +260,7 @@ const FAQSection = () => {
 
         .faq-section {
           padding: 5rem 0;
-          background-color: var(--background);
+          background: linear-gradient(to left, var(--contrast1), var(--contrast2), var(--contrast3));
           position: relative;
           overflow: hidden;
         }

--- a/components/sections/FeaturesSection.js
+++ b/components/sections/FeaturesSection.js
@@ -69,7 +69,7 @@ const FeaturesSection = () => {
           padding: 8rem 0 5rem;
           position: relative;
           overflow: visible;
-          background-color: var(--background);
+background: linear-gradient(to right, var(--contrast1), var(--contrast2), var(--contrast3));
           z-index: 1;
         }
         

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,6 +23,9 @@
   --text: #333333;
   --text-light: #666666;
   --background: #ffffff;
+  --contrast1: #96beeefd;
+  --contrast2: #d5e9ffc1;
+  --contrast3: #e9f3faff;
   --background-alt: #f5f7fa;
   --border: #e0e0e0;
   --shadow: rgba(0, 0, 0, 0.1);
@@ -52,6 +55,9 @@
   --text: #f0f0f0;
   --text-light: #b0b0b0;
   --background: #121212;
+  --contrast1: #121212;
+  --contrast2: #121212;
+  --contrast3: #121212;
   --background-alt: #1e1e2e;
   --border: #2a2a3a;
   --shadow: rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

Improved the background contrast between homepage sections in light mode to enhance visual clarity and maintain consistency across sections.
Ensured that dark mode styling remains unaffected.

Fixes: #323

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [x] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Eventmappr
- [x] I have tested my changes locally
- [x] I have updated relevant documentation
- [x] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Before--
<img width="714" height="1030" alt="image" src="https://github.com/user-attachments/assets/ac50899b-fd01-4a20-aaa4-95e9cb5c927b" />

After--
<img width="866" height="1025" alt="image" src="https://github.com/user-attachments/assets/3921a16b-ae9a-4e2b-9547-6ffcd4e29c9a" />

<img width="1879" height="1025" alt="image" src="https://github.com/user-attachments/assets/c38c8033-e1c2-4a07-b4a7-f6ed875867ef" />

<img width="1791" height="952" alt="image" src="https://github.com/user-attachments/assets/c69fc29d-4572-4371-ac9a-3cf0d1c00b9a" />

##Additional Info:
Used variables for light mode gradient and ensured dark mode compatibility in the dark theme scope.
