### PR TITLE
feat: Add dark mode support for splash screen

### DIFF
--- a/components/LoadingSpinner.js
+++ b/components/LoadingSpinner.js
@@ -1,13 +1,69 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function LoadingSpinner({ fullPage = false }) {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    // Función para detectar el tema actual
+    const getCurrentTheme = () => {
+      // Primero intentar obtener el tema del atributo data-theme
+      const dataTheme = document.documentElement.getAttribute('data-theme');
+      if (dataTheme) {
+        return dataTheme === 'dark';
+      }
+      
+      // Si no hay data-theme, usar el tema del sistema
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      return mediaQuery.matches;
+    };
+
+    // Establecer el tema inicial
+    setIsDarkMode(getCurrentTheme());
+
+    // Observar cambios en el atributo data-theme
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+          setIsDarkMode(getCurrentTheme());
+        }
+      });
+    });
+
+    // Observar cambios en el document.documentElement
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    });
+
+    // También escuchar cambios del sistema
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemThemeChange = () => {
+      // Solo actualizar si no hay tema manual establecido
+      if (!document.documentElement.getAttribute('data-theme')) {
+        setIsDarkMode(mediaQuery.matches);
+      }
+    };
+    
+    mediaQuery.addEventListener('change', handleSystemThemeChange);
+
+    // Cleanup
+    return () => {
+      observer.disconnect();
+      mediaQuery.removeEventListener('change', handleSystemThemeChange);
+    };
+  }, []);
+
   return (
     <div className={fullPage ? 'spinner-fullpage' : 'spinner-overlay'}>
       <div className="splash-container">
         <div className="splash-content">
           <div className="spinner-container">
             <div className="spinner-ring"></div>
-            <img src="/logg.svg" alt="Logo" className="spinner-logo" />
+            <img 
+              src={isDarkMode ? "/loggd.svg" : "/logg.svg"} 
+              alt="Logo" 
+              className="spinner-logo" 
+            />
           </div>
           <div className="splash-text">
             <div className="splash-title">EventMappr</div>
@@ -22,37 +78,41 @@ export default function LoadingSpinner({ fullPage = false }) {
           left: 0;
           width: 100vw;
           height: 100vh;
-          background: linear-gradient(135deg, 
-            rgba(255, 255, 255, 0.95) 0%,
-            rgba(255, 255, 255, 0.85) 100%
-          );
+          background: ${isDarkMode 
+            ? 'linear-gradient(135deg, rgba(10, 10, 15, 0.98) 0%, rgba(19, 19, 26, 0.95) 100%)' 
+            : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.85) 100%)'
+          };
           display: flex;
           align-items: center;
           justify-content: center;
           z-index: 9999;
+          transition: background 0.4s ease;
         }
         .spinner-fullpage {
           min-height: 100vh;
           width: 100vw;
-          background: linear-gradient(135deg, 
-            rgba(255, 255, 255, 0.95) 0%,
-            rgba(255, 255, 255, 0.85) 100%
-          );
+          background: ${isDarkMode 
+            ? 'linear-gradient(135deg, rgba(10, 10, 15, 0.98) 0%, rgba(19, 19, 26, 0.95) 100%)' 
+            : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.85) 100%)'
+          };
           display: flex;
           align-items: center;
           justify-content: center;
-          transition: background 0.4s;
+          transition: background 0.4s ease;
         }
         .splash-container {
-          background: rgba(255, 255, 255, 0.9);
+          background: ${isDarkMode 
+            ? 'rgba(26, 26, 35, 0.95)' 
+            : 'rgba(255, 255, 255, 0.9)'
+          };
           backdrop-filter: blur(16px);
           -webkit-backdrop-filter: blur(16px);
           border-radius: 32px;
           padding: 2.5rem;
-          box-shadow: 
-            0 8px 32px rgba(0, 0, 0, 0.02),
-            0 16px 48px rgba(0, 0, 0, 0.03),
-            inset 0 0 40px rgba(var(--primary-rgb, 52, 152, 219), 0.05);
+          box-shadow: ${isDarkMode
+            ? '0 8px 32px rgba(0, 0, 0, 0.4), 0 16px 48px rgba(0, 0, 0, 0.3), inset 0 0 40px rgba(90, 144, 255, 0.08)'
+            : '0 8px 32px rgba(0, 0, 0, 0.02), 0 16px 48px rgba(0, 0, 0, 0.03), inset 0 0 40px rgba(52, 152, 219, 0.05)'
+          };
           display: flex;
           align-items: center;
           justify-content: center;
@@ -60,7 +120,10 @@ export default function LoadingSpinner({ fullPage = false }) {
           max-width: 480px;
           height: 320px;
           transition: all 0.3s ease;
-          border: 1px solid rgba(255, 255, 255, 0.1);
+          border: 1px solid ${isDarkMode 
+            ? 'rgba(90, 144, 255, 0.2)' 
+            : 'rgba(255, 255, 255, 0.1)'
+          };
           position: relative;
           overflow: hidden;
         }
@@ -74,7 +137,10 @@ export default function LoadingSpinner({ fullPage = false }) {
           background: linear-gradient(
             45deg,
             transparent 0%,
-            rgba(var(--primary-rgb, 52, 152, 219), 0.05) 50%,
+            ${isDarkMode 
+              ? 'rgba(90, 144, 255, 0.08)' 
+              : 'rgba(52, 152, 219, 0.05)'
+            } 50%,
             transparent 100%
           );
           animation: shine 8s infinite;
@@ -100,24 +166,35 @@ export default function LoadingSpinner({ fullPage = false }) {
           position: absolute;
           width: 160px;
           height: 160px;
-          border: 5px solid rgba(var(--primary-rgb, 52, 152, 219), 0.2);
-          border-top: 5px solid var(--primary, #3498db);
-          border-bottom: 5px solid var(--primary-light, #6ec1e4);
+          border: 5px solid ${isDarkMode 
+            ? 'rgba(90, 144, 255, 0.2)' 
+            : 'rgba(52, 152, 219, 0.2)'
+          };
+          border-top: 5px solid ${isDarkMode 
+            ? '#5a90ff' 
+            : '#3498db'
+          };
+          border-bottom: 5px solid ${isDarkMode 
+            ? '#7aa5ff' 
+            : '#6ec1e4'
+          };
           border-radius: 50%;
           animation: spin 1.4s cubic-bezier(0.4, 0.2, 0.2, 1) infinite;
-          box-shadow: 
-            0 0 48px 0 rgba(var(--primary-rgb, 52, 152, 219), 0.15),
-            0 0 80px 0 rgba(var(--primary-rgb, 52, 152, 219), 0.08);
+          box-shadow: ${isDarkMode
+            ? '0 0 48px 0 rgba(90, 144, 255, 0.25), 0 0 80px 0 rgba(90, 144, 255, 0.15)'
+            : '0 0 48px 0 rgba(52, 152, 219, 0.15), 0 0 80px 0 rgba(52, 152, 219, 0.08)'
+          };
           background: transparent;
         }
         .spinner-logo {
           width: 112px;
           height: 112px;
           border-radius: 28px;
-          background: white;
-          box-shadow: 
-            0 12px 48px rgba(var(--primary-rgb, 52, 152, 219), 0.1),
-            0 6px 24px rgba(0, 0, 0, 0.03);
+          background: ${isDarkMode ? '#1a1a23' : 'white'};
+          box-shadow: ${isDarkMode
+            ? '0 12px 48px rgba(90, 144, 255, 0.15), 0 6px 24px rgba(0, 0, 0, 0.1)'
+            : '0 12px 48px rgba(52, 152, 219, 0.1), 0 6px 24px rgba(0, 0, 0, 0.03)'
+          };
           z-index: 2;
           object-fit: contain;
           padding: 16px;
@@ -130,16 +207,19 @@ export default function LoadingSpinner({ fullPage = false }) {
         .splash-title {
           font-size: 2.4rem;
           font-weight: 700;
-          color: var(--primary, #3498db);
+          color: ${isDarkMode ? '#f0f0f0' : '#3498db'};
           letter-spacing: -0.6px;
           margin-bottom: 0.6rem;
-          text-shadow: 0 2px 12px rgba(var(--primary-rgb, 52, 152, 219), 0.15);
+          text-shadow: ${isDarkMode
+            ? '0 2px 12px rgba(90, 144, 255, 0.2)'
+            : '0 2px 12px rgba(52, 152, 219, 0.15)'
+          };
           position: relative;
           z-index: 2;
         }
         .splash-subtitle {
           font-size: 1.2rem;
-          color: var(--text-light, #666);
+          color: ${isDarkMode ? '#b0b0b0' : '#666'};
           opacity: 0.9;
           position: relative;
           z-index: 2;
@@ -176,125 +256,6 @@ export default function LoadingSpinner({ fullPage = false }) {
           }
           .splash-title {
             font-size: 2rem;
-          }
-          .splash-subtitle {
-            font-size: 1rem;
-            var(--background, #ffffff) 0%,
-            rgba(var(--background-rgb, 255, 255, 255), 0.9) 100%
-          );
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          z-index: 9999;
-        }
-        .spinner-fullpage {
-          min-height: 100vh;
-          width: 100vw;
-          background: linear-gradient(135deg, 
-            var(--background, #ffffff) 0%,
-            rgba(var(--background-rgb, 255, 255, 255), 0.9) 100%
-          );
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          transition: background 0.4s;
-        }
-        .splash-container {
-          background: rgba(255, 255, 255, 0.95);
-          backdrop-filter: blur(12px);
-          border-radius: 24px;
-          padding: 2rem;
-          box-shadow: 
-            0 8px 32px rgba(var(--primary-rgb, 52, 152, 219), 0.05),
-            0 16px 48px rgba(var(--primary-rgb, 52, 152, 219), 0.03);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-width: 280px;
-          max-width: 400px;
-          height: 280px;
-          transition: all 0.3s ease;
-        }
-        .splash-content {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: 1.5rem;
-        }
-        .spinner-container {
-          position: relative;
-          width: 140px;
-          height: 140px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        .spinner-ring {
-          position: absolute;
-          width: 140px;
-          height: 140px;
-          border: 4px solid rgba(var(--primary-rgb, 52, 152, 219), 0.2);
-          border-top: 4px solid var(--primary, #3498db);
-          border-bottom: 4px solid var(--primary-light, #6ec1e4);
-          border-radius: 50%;
-          animation: spin 1.2s cubic-bezier(0.4, 0.2, 0.2, 1) infinite;
-          box-shadow: 
-            0 0 40px 0 rgba(var(--primary-rgb, 52, 152, 219), 0.1),
-            0 0 60px 0 rgba(var(--primary-rgb, 52, 152, 219), 0.05);
-          background: transparent;
-        }
-        .spinner-logo {
-          width: 96px;
-          height: 96px;
-          border-radius: 24px;
-          background: white;
-          box-shadow: 
-            0 8px 32px rgba(var(--primary-rgb, 52, 152, 219), 0.08),
-            0 4px 16px rgba(0, 0, 0, 0.03);
-          z-index: 2;
-          object-fit: contain;
-          padding: 12px;
-        }
-        .splash-text {
-          text-align: center;
-        }
-        .splash-title {
-          font-size: 2.2rem;
-          font-weight: 700;
-          color: var(--primary, #3498db);
-          letter-spacing: -0.5px;
-          margin-bottom: 0.5rem;
-          text-shadow: 0 2px 8px rgba(var(--primary-rgb, 52, 152, 219), 0.1);
-        }
-        .splash-subtitle {
-          font-size: 1.1rem;
-          color: var(--text-light, #666);
-          opacity: 0.9;
-        }
-        @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
-        @media (max-width: 600px) {
-          .splash-container {
-            padding: 1.5rem;
-            min-width: 240px;
-            height: 240px;
-          }
-          .spinner-container {
-            width: 120px;
-            height: 120px;
-          }
-          .spinner-ring {
-            width: 120px;
-            height: 120px;
-          }
-          .spinner-logo {
-            width: 80px;
-            height: 80px;
-          }
-          .splash-title {
-            font-size: 1.8rem;
           }
           .splash-subtitle {
             font-size: 1rem;


### PR DESCRIPTION
# 📦 Pull Request: Eventmappr Contribution

## ✅ Description

Implements dark mode support for the splash screen component to provide a consistent user experience across different theme preferences. The splash screen now automatically detects the user's theme preference (system or manually set) and displays the appropriate version with matching colors and logo.

**Key Changes:**
- ✨ Auto-detection of user's theme preference using `prefers-color-scheme` and `data-theme` attributes
- 🎨 Dynamic logo switching between light (`logg.svg`) and dark (`loggd.svg`) versions
- 🌙 Dark theme-specific background gradients, colors, and shadows
- 🔄 Smooth transitions between theme changes
- 📱 Maintained responsive design for all screen sizes
- 🎯 Consistent visual integration with the existing dark mode system

**Technical Implementation:**
- Added `useState` and `useEffect` hooks for theme detection
- Implemented `MutationObserver` to watch for theme changes
- Added `prefers-color-scheme` media query listener for system theme detection
- Updated CSS-in-JS styles with conditional rendering based on `isDarkMode` state

Fixes: #425 

## 📂 Type of Change

- [ ] Bug Fix 🐛
- [x] New Feature ✨
- [ ] Documentation 📚
- [x] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Eventmappr
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [x] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

In dark mode: 
<img width="2880" height="1554" alt="image" src="https://github.com/user-attachments/assets/f40baa79-2b04-4362-9479-f3fa97560a12" />

In light mode: 
<img width="2880" height="1554" alt="image" src="https://github.com/user-attachments/assets/95aa2619-aae6-48c1-9a1c-5c4e25889f97" />

